### PR TITLE
fix order by multiple columns

### DIFF
--- a/Datagrid/DoctrineDatagrid.php
+++ b/Datagrid/DoctrineDatagrid.php
@@ -446,7 +446,7 @@ class DoctrineDatagrid
         $sort = $this->getSessionValue('sort', $this->defaultSorts);
 
         foreach ($sort as $column => $order) {
-            $this->getQueryBuilder()->orderBy($column, $order);
+            $this->getQueryBuilder()->addOrderBy($column, $order);
         }
     }
 


### PR DESCRIPTION
If we add multiple default sorts, like that :
```
$this->datagrid
  ->setDefaultSort([
    'secteur.nom' => 'ASC',
    'equipe.nom' => 'ASC',
  ]);
```
Only the last sort is applied to query due to the call of `->orderBy()` function instead of `->addOrderBy()` on QueryBuilder
https://www.doctrine-project.org/api/orm/2.7/Doctrine/ORM/QueryBuilder.html#method_addOrderBy