### PR TITLE
Added method parameter to make GET method possible to use

### DIFF
--- a/Datagrid/DoctrineDatagrid.php
+++ b/Datagrid/DoctrineDatagrid.php
@@ -454,6 +454,9 @@ class DoctrineDatagrid
 
     public function getAllowedFilterMethods()
     {
+        if (isset($this->params['method']) && ('get' == $this->params['method'])) {
+            return ['get'];
+        }
         return ['post'];
     }
 


### PR DESCRIPTION
Because it was not possible to configure the method, a parameter check was added, instead of a hard coded variable.
When an incorrect name is used in the URL, a Form error is raised by Symfony.